### PR TITLE
전역에서 발생하는 예외 처리

### DIFF
--- a/src/main/java/com/woowa/supp/domain/surveyee/DeveloperType.java
+++ b/src/main/java/com/woowa/supp/domain/surveyee/DeveloperType.java
@@ -12,6 +12,8 @@ public enum DeveloperType {
     CODE_GUARDIAN("Code Guardian"),
     NINJA("Ninja");
 
+    static final String TYPE_NOT_FOUND = "해당 타입이 존재하지 않습니다 : %s";
+
     private final String title;
 
     DeveloperType(String title) {
@@ -22,6 +24,7 @@ public enum DeveloperType {
         return Arrays.stream(DeveloperType.values())
                 .filter(developerType -> developerType.title.equals(title))
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("해당 타입이 존재하지 않습니다 : " + title));
+                .orElseThrow(
+                        () -> new IllegalArgumentException(String.format(TYPE_NOT_FOUND, title)));
     }
 }

--- a/src/main/java/com/woowa/supp/domain/surveyee/DeveloperType.java
+++ b/src/main/java/com/woowa/supp/domain/surveyee/DeveloperType.java
@@ -6,22 +6,22 @@ import lombok.Getter;
 
 @Getter
 public enum DeveloperType {
-	MAD_SCIENTIST("Mad Scientist"),
-	MACGYVER("MacGyver"),
-	THE_ARCHITECT("The Architect"),
-	CODE_GUARDIAN("Code Guardian"),
-	NINJA("Ninja");
+    MAD_SCIENTIST("Mad Scientist"),
+    MACGYVER("MacGyver"),
+    THE_ARCHITECT("The Architect"),
+    CODE_GUARDIAN("Code Guardian"),
+    NINJA("Ninja");
 
-	private final String title;
+    private final String title;
 
-	DeveloperType(String title) {
-		this.title = title;
-	}
+    DeveloperType(String title) {
+        this.title = title;
+    }
 
-	public static DeveloperType of(String title) {
-		return Arrays.stream(DeveloperType.values())
-		             .filter(developerType -> developerType.title.equals(title))
-		             .findFirst()
-		             .orElseThrow(() -> new IllegalArgumentException(title + " : no matched type"));
-	}
+    public static DeveloperType of(String title) {
+        return Arrays.stream(DeveloperType.values())
+                .filter(developerType -> developerType.title.equals(title))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("해당 타입이 존재하지 않습니다 : " + title));
+    }
 }

--- a/src/main/java/com/woowa/supp/domain/surveyee/SurveyeeRepository.java
+++ b/src/main/java/com/woowa/supp/domain/surveyee/SurveyeeRepository.java
@@ -5,6 +5,5 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SurveyeeRepository extends JpaRepository<Surveyee, Long> {
-
 	Optional<Surveyee> findByLogin(String login);
 }

--- a/src/main/java/com/woowa/supp/domain/surveyee/style/AfterStudyStyle.java
+++ b/src/main/java/com/woowa/supp/domain/surveyee/style/AfterStudyStyle.java
@@ -3,20 +3,20 @@ package com.woowa.supp.domain.surveyee.style;
 import java.util.Arrays;
 
 public enum AfterStudyStyle {
-	MORE_PAIR("밥먹고 더할까요?"),
-	WRAP_UP("내일 마무리 해보죠."),
-	WAIT_PAIR_SUGGESTION("상대방의 말을 기다린다.");
+    MORE_PAIR("밥먹고 더할까요?"),
+    WRAP_UP("내일 마무리 해보죠."),
+    WAIT_PAIR_SUGGESTION("상대방의 말을 기다린다.");
 
-	private final String title;
+    private final String title;
 
-	AfterStudyStyle(String title) {
-		this.title = title;
-	}
+    AfterStudyStyle(String title) {
+        this.title = title;
+    }
 
-	public static AfterStudyStyle of(String title) {
-		return Arrays.stream(AfterStudyStyle.values())
-		             .filter(value -> value.title.equals(title))
-		             .findFirst()
-		             .orElseThrow(() -> new IllegalArgumentException(title + ": 적절하지 않은 답변 이름 입니다."));
-	}
+    public static AfterStudyStyle of(String title) {
+        return Arrays.stream(AfterStudyStyle.values())
+                .filter(value -> value.title.equals(title))
+                .findFirst()
+                .orElseThrow(() -> new InvalidStyleException(title));
+    }
 }

--- a/src/main/java/com/woowa/supp/domain/surveyee/style/BreaktimeStyle.java
+++ b/src/main/java/com/woowa/supp/domain/surveyee/style/BreaktimeStyle.java
@@ -3,20 +3,20 @@ package com.woowa.supp.domain.surveyee.style;
 import java.util.Arrays;
 
 public enum BreaktimeStyle {
-	NO_BREAK("저는 진짜 힘들때까진 계속 코딩 하는 편이에요."),
-	SCHEDULED_BREAK("저는 일정 시간마다 쉬어야 합니다."),
-	DONT_CARE("저는 뭐... 상관 없습니다.");
+    NO_BREAK("저는 진짜 힘들때까진 계속 코딩 하는 편이에요."),
+    SCHEDULED_BREAK("저는 일정 시간마다 쉬어야 합니다."),
+    DONT_CARE("저는 뭐... 상관 없습니다.");
 
-	private final String title;
+    private final String title;
 
-	BreaktimeStyle(String title) {
-		this.title = title;
-	}
+    BreaktimeStyle(String title) {
+        this.title = title;
+    }
 
-	public static BreaktimeStyle of(String title) {
-		return Arrays.stream(BreaktimeStyle.values())
-		             .filter(value -> value.title.equals(title))
-		             .findFirst()
-		             .orElseThrow(() -> new IllegalArgumentException(title + ": 적절하지 않은 답변 이름 입니다."));
-	}
+    public static BreaktimeStyle of(String title) {
+        return Arrays.stream(BreaktimeStyle.values())
+                .filter(value -> value.title.equals(title))
+                .findFirst()
+                .orElseThrow(() -> new InvalidStyleException(title));
+    }
 }

--- a/src/main/java/com/woowa/supp/domain/surveyee/style/ComputerPreferStyle.java
+++ b/src/main/java/com/woowa/supp/domain/surveyee/style/ComputerPreferStyle.java
@@ -3,21 +3,21 @@ package com.woowa.supp.domain.surveyee.style;
 import java.util.Arrays;
 
 public enum ComputerPreferStyle {
-	MY_COMPUTER("내 컴퓨터"),
-	PAIR_COMPUTER("페어의 컴퓨터"),
-	DONT_CARE("아무거나"),
-	IN_TURN("번갈아가며");
+    MY_COMPUTER("내 컴퓨터"),
+    PAIR_COMPUTER("페어의 컴퓨터"),
+    DONT_CARE("아무거나"),
+    IN_TURN("번갈아가며");
 
-	private final String title;
+    private final String title;
 
-	ComputerPreferStyle(String title) {
-		this.title = title;
-	}
+    ComputerPreferStyle(String title) {
+        this.title = title;
+    }
 
-	public static ComputerPreferStyle of(String title) {
-		return Arrays.stream(ComputerPreferStyle.values())
-		             .filter(value -> value.title.equals(title))
-		             .findFirst()
-		             .orElseThrow(() -> new IllegalArgumentException(title + ": 적절하지 않은 답변 이름 입니다."));
-	}
+    public static ComputerPreferStyle of(String title) {
+        return Arrays.stream(ComputerPreferStyle.values())
+                .filter(value -> value.title.equals(title))
+                .findFirst()
+                .orElseThrow(() -> new InvalidStyleException(title));
+    }
 }

--- a/src/main/java/com/woowa/supp/domain/surveyee/style/InvalidStyleException.java
+++ b/src/main/java/com/woowa/supp/domain/surveyee/style/InvalidStyleException.java
@@ -1,0 +1,14 @@
+package com.woowa.supp.domain.surveyee.style;
+
+public class InvalidStyleException extends IllegalArgumentException {
+    static final String USER_NOT_FOUND = "해당 스타일이 존재하지 않습니다 : %s";
+
+    InvalidStyleException(String style) {
+        super(String.format(USER_NOT_FOUND, style));
+    }
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this;
+    }
+}

--- a/src/main/java/com/woowa/supp/domain/surveyee/style/InvalidStyleException.java
+++ b/src/main/java/com/woowa/supp/domain/surveyee/style/InvalidStyleException.java
@@ -1,10 +1,10 @@
 package com.woowa.supp.domain.surveyee.style;
 
 public class InvalidStyleException extends IllegalArgumentException {
-    static final String USER_NOT_FOUND = "해당 스타일이 존재하지 않습니다 : %s";
+    static final String STYLE_NOT_FOUND = "해당 스타일이 존재하지 않습니다 : %s";
 
     InvalidStyleException(String style) {
-        super(String.format(USER_NOT_FOUND, style));
+        super(String.format(STYLE_NOT_FOUND, style));
     }
 
     @Override

--- a/src/main/java/com/woowa/supp/domain/surveyee/style/OSStyle.java
+++ b/src/main/java/com/woowa/supp/domain/surveyee/style/OSStyle.java
@@ -3,20 +3,20 @@ package com.woowa.supp.domain.surveyee.style;
 import java.util.Arrays;
 
 public enum OSStyle {
-	APPLE("사과"),
-	WINDOWS("창문"),
-	LINUX("펭귄");
+    APPLE("사과"),
+    WINDOWS("창문"),
+    LINUX("펭귄");
 
-	private final String title;
+    private final String title;
 
-	OSStyle(String title) {
-		this.title = title;
-	}
+    OSStyle(String title) {
+        this.title = title;
+    }
 
-	public static OSStyle of(String title) {
-		return Arrays.stream(OSStyle.values())
-		             .filter(value -> value.title.equals(title))
-		             .findFirst()
-		             .orElseThrow(() -> new IllegalArgumentException(title + ": 적절하지 않은 답변 이름 입니다."));
-	}
+    public static OSStyle of(String title) {
+        return Arrays.stream(OSStyle.values())
+                .filter(value -> value.title.equals(title))
+                .findFirst()
+                .orElseThrow(() -> new InvalidStyleException(title));
+    }
 }

--- a/src/main/java/com/woowa/supp/domain/surveyee/style/PairTurnStyle.java
+++ b/src/main/java/com/woowa/supp/domain/surveyee/style/PairTurnStyle.java
@@ -3,20 +3,20 @@ package com.woowa.supp.domain.surveyee.style;
 import java.util.Arrays;
 
 public enum PairTurnStyle {
-	TURN_BY_TIME("시간을 정해서 돌아간다."),
-	TURN_BY_FUNCTION("기능을 정해서 돌아간다."),
-	DONT_CARE("상관 없다.");
+    TURN_BY_TIME("시간을 정해서 돌아간다."),
+    TURN_BY_FUNCTION("기능을 정해서 돌아간다."),
+    DONT_CARE("상관 없다.");
 
-	private final String title;
+    private final String title;
 
-	PairTurnStyle(String title) {
-		this.title = title;
-	}
+    PairTurnStyle(String title) {
+        this.title = title;
+    }
 
-	public static PairTurnStyle of(String title) {
-		return Arrays.stream(PairTurnStyle.values())
-		             .filter(value -> value.title.equals(title))
-		             .findFirst()
-		             .orElseThrow(() -> new IllegalArgumentException(title + ": 적절하지 않은 답변 이름 입니다."));
-	}
+    public static PairTurnStyle of(String title) {
+        return Arrays.stream(PairTurnStyle.values())
+                .filter(value -> value.title.equals(title))
+                .findFirst()
+                .orElseThrow(() -> new InvalidStyleException(title));
+    }
 }

--- a/src/main/java/com/woowa/supp/service/SurveyService.java
+++ b/src/main/java/com/woowa/supp/service/SurveyService.java
@@ -13,61 +13,64 @@ import com.woowa.supp.domain.surveyee.SurveyeeRepository;
 import com.woowa.supp.web.dto.DeveloperTypeSaveRequestDto;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * @throws UserNotFoundException 우아한테크코스 사이트에서 페어의 결과 아이콘 클릭 시 페어(사용자)가 존재하지 않을 경우, SUPP 페이지에서 로그인 한 사용자가 존재지 않을 경우
+ */
 @RequiredArgsConstructor
 @Service
 public class SurveyService {
 
-	private final SurveyeeRepository surveyeeRepository;
+    private final SurveyeeRepository surveyeeRepository;
 
-	@Transactional
-	public Long saveOrUpdateType(DeveloperTypeSaveRequestDto requestDto, SessionUser user) {
-		Optional<Surveyee> persist = surveyeeRepository.findByLogin(user.getLogin());
-		if (persist.isPresent()) {
-			return updateType(requestDto, persist.get());
-		}
-		return saveType(requestDto, user);
-	}
+    @Transactional
+    public Long saveOrUpdateType(DeveloperTypeSaveRequestDto requestDto, SessionUser user) {
+        Optional<Surveyee> persist = findOptionalByUser(user);
+        if (persist.isPresent()) {
+            return updateType(requestDto, persist.get());
+        }
+        return saveType(requestDto, user);
+    }
 
-	private Long updateType(DeveloperTypeSaveRequestDto requestDto, Surveyee persist) {
-		persist.updateTypeBy(requestDto.toEntity());
-		return persist.getId();
-	}
+    @Transactional(readOnly = true)
+    public Optional<Surveyee> findOptionalByUser(SessionUser user) {
+        return surveyeeRepository.findByLogin(user.getLogin());
+    }
 
-	private Long saveType(DeveloperTypeSaveRequestDto requestDto,
-			@LoginUser SessionUser sessionUser) {
-		Surveyee surveyee = Surveyee.builder()
-				.login(sessionUser.getLogin())
-				.avatar(sessionUser.getAvatar())
-				.developerType(requestDto.toEntity())
-				.build();
+    private Long updateType(DeveloperTypeSaveRequestDto requestDto, Surveyee persist) {
+        persist.updateTypeBy(requestDto.toEntity());
+        return persist.getId();
+    }
 
-		return surveyeeRepository.save(surveyee).getId();
-	}
+    private Long saveType(DeveloperTypeSaveRequestDto requestDto,
+            @LoginUser SessionUser sessionUser) {
+        Surveyee surveyee = Surveyee.builder()
+                .login(sessionUser.getLogin())
+                .avatar(sessionUser.getAvatar())
+                .developerType(requestDto.toEntity())
+                .build();
 
-	@Transactional
-	public Long saveStyle(Map<String, Object> styles, @LoginUser SessionUser sessionUser) {
-		Optional<Surveyee> persist = surveyeeRepository.findByLogin(sessionUser.getLogin());
-		if (persist.isPresent()) {
-			persist.get().updateStylesBy(styles);
-			return persist.get().getId();
-		}
-		throw new UserNotFoundException(sessionUser.getLogin());
-	}
+        return surveyeeRepository.save(surveyee).getId();
+    }
 
-	@Transactional(readOnly = true)
-	public Optional<Surveyee> findOptionalByUser(SessionUser user) {
-		return surveyeeRepository.findByLogin(user.getLogin());
-	}
+    @Transactional
+    public Long saveStyle(Map<String, Object> styles, @LoginUser SessionUser sessionUser) {
+        Optional<Surveyee> persist = findOptionalByUser(sessionUser);
+        if (persist.isPresent()) {
+            persist.get().updateStylesBy(styles);
+            return persist.get().getId();
+        }
+        throw new UserNotFoundException(sessionUser.getLogin());
+    }
 
-	@Transactional(readOnly = true)
-	public Surveyee findByUser(SessionUser user) {
-		return findByLogin(user.getLogin());
-	}
+    @Transactional(readOnly = true)
+    public Surveyee findByUser(SessionUser user) {
+        return findByLogin(user.getLogin());
+    }
 
-	@Transactional(readOnly = true)
-	public Surveyee findByLogin(String login) {
-		return surveyeeRepository.findByLogin(login)
-				.orElseThrow(() -> new UserNotFoundException(login));
-	}
+    @Transactional(readOnly = true)
+    public Surveyee findByLogin(String login) {
+        return surveyeeRepository.findByLogin(login)
+                .orElseThrow(() -> new UserNotFoundException(login));
+    }
 }
 

--- a/src/main/java/com/woowa/supp/service/SurveyService.java
+++ b/src/main/java/com/woowa/supp/service/SurveyService.java
@@ -33,12 +33,13 @@ public class SurveyService {
 		return persist.getId();
 	}
 
-	private Long saveType(DeveloperTypeSaveRequestDto requestDto, @LoginUser SessionUser sessionUser) {
+	private Long saveType(DeveloperTypeSaveRequestDto requestDto,
+			@LoginUser SessionUser sessionUser) {
 		Surveyee surveyee = Surveyee.builder()
-			.login(sessionUser.getLogin())
-			.avatar(sessionUser.getAvatar())
-			.developerType(requestDto.toEntity())
-			.build();
+				.login(sessionUser.getLogin())
+				.avatar(sessionUser.getAvatar())
+				.developerType(requestDto.toEntity())
+				.build();
 
 		return surveyeeRepository.save(surveyee).getId();
 	}
@@ -50,7 +51,7 @@ public class SurveyService {
 			persist.get().updateStylesBy(styles);
 			return persist.get().getId();
 		}
-		throw new IllegalArgumentException("존재하지 않는 surveyee 입니다. sessionUser = " + sessionUser.getLogin());
+		throw new UserNotFoundException(sessionUser.getLogin());
 	}
 
 	@Transactional(readOnly = true)
@@ -60,14 +61,13 @@ public class SurveyService {
 
 	@Transactional(readOnly = true)
 	public Surveyee findByUser(SessionUser user) {
-		return surveyeeRepository.findByLogin(user.getLogin())
-			.orElseThrow(() -> new IllegalArgumentException(
-				"존재하지 않는 유저 입니다. name = " + user.getName() + "id = " + user.getLogin()));
+		return findByLogin(user.getLogin());
 	}
 
 	@Transactional(readOnly = true)
 	public Surveyee findByLogin(String login) {
 		return surveyeeRepository.findByLogin(login)
-			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저 입니다. id = " + login));
+				.orElseThrow(() -> new UserNotFoundException(login));
 	}
 }
+

--- a/src/main/java/com/woowa/supp/service/UserNotFoundException.java
+++ b/src/main/java/com/woowa/supp/service/UserNotFoundException.java
@@ -6,5 +6,9 @@ public class UserNotFoundException extends IllegalArgumentException {
     UserNotFoundException(String id) {
         super(String.format(USER_NOT_FOUND, id));
     }
-}
 
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this;
+    }
+}

--- a/src/main/java/com/woowa/supp/service/UserNotFoundException.java
+++ b/src/main/java/com/woowa/supp/service/UserNotFoundException.java
@@ -1,0 +1,10 @@
+package com.woowa.supp.service;
+
+public class UserNotFoundException extends IllegalArgumentException {
+    static final String USER_NOT_FOUND = "유저가 존재하지 않습니다 : %s";
+
+    UserNotFoundException(String id) {
+        super(String.format(USER_NOT_FOUND, id));
+    }
+}
+

--- a/src/main/java/com/woowa/supp/web/ControllerAdvice.java
+++ b/src/main/java/com/woowa/supp/web/ControllerAdvice.java
@@ -1,0 +1,29 @@
+package com.woowa.supp.web;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.woowa.supp.domain.surveyee.style.InvalidStyleException;
+import com.woowa.supp.service.UserNotFoundException;
+
+@RestControllerAdvice
+public class ControllerAdvice {
+    @ExceptionHandler({IllegalArgumentException.class, UserNotFoundException.class,
+            InvalidStyleException.class})
+    private ErrorMessage handleExpectedException(IllegalArgumentException e) {
+        ErrorMessage errorMessage = new ErrorMessage();
+        errorMessage.setStatus(HttpStatus.BAD_REQUEST.toString());
+        errorMessage.setMessage(e.getMessage());
+        return errorMessage;
+    }
+
+    @ExceptionHandler(Exception.class)
+    private ErrorMessage handleUnexpectedException(Exception e) {
+        ErrorMessage errorMessage = new ErrorMessage();
+        errorMessage.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.toString());
+        errorMessage.setMessage(
+                "예기치 못한 에러가 발생했습니다. \n 개발자가 열심히 확인하고 있습니다. 🔧 \n " + e.getMessage());
+        return errorMessage;
+    }
+}

--- a/src/main/java/com/woowa/supp/web/ErrorMessage.java
+++ b/src/main/java/com/woowa/supp/web/ErrorMessage.java
@@ -1,0 +1,19 @@
+package com.woowa.supp.web;
+
+public class ErrorMessage {
+    private String status;
+    private String message;
+
+    public String getStatus() {
+        return status;
+    }
+    public void setStatus(String status) {
+        this.status = status;
+    }
+    public String getMessage() {
+        return message;
+    }
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/test/java/com/woowa/supp/domain/surveyee/DeveloperTypeTest.java
+++ b/src/test/java/com/woowa/supp/domain/surveyee/DeveloperTypeTest.java
@@ -1,0 +1,26 @@
+package com.woowa.supp.domain.surveyee;
+
+import static com.woowa.supp.domain.surveyee.DeveloperType.*;
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class DeveloperTypeTest {
+    @Test
+    void of() {
+        DeveloperType expected = DeveloperType.MAD_SCIENTIST;
+        DeveloperType actual = DeveloperType.of("Mad Scientist");
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void of_GivenInvalidDeveloperType() {
+        String invalidDeveloperType = "ESFJ";
+
+        assertThatThrownBy(() -> DeveloperType.of(invalidDeveloperType))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(TYPE_NOT_FOUND, invalidDeveloperType);
+    }
+}

--- a/src/test/java/com/woowa/supp/domain/surveyee/style/AfterStudyStyleTest.java
+++ b/src/test/java/com/woowa/supp/domain/surveyee/style/AfterStudyStyleTest.java
@@ -1,0 +1,26 @@
+package com.woowa.supp.domain.surveyee.style;
+
+import static com.woowa.supp.domain.surveyee.style.InvalidStyleException.*;
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class AfterStudyStyleTest {
+    @Test
+    void of() {
+        AfterStudyStyle expected = AfterStudyStyle.MORE_PAIR;
+        AfterStudyStyle actual = AfterStudyStyle.of("밥먹고 더할까요?");
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void of_GivenInvalidAfterStudyStyle() {
+        String invalidAfterStudyStyle = "메롱 안해";
+
+        assertThatThrownBy(() -> AfterStudyStyle.of(invalidAfterStudyStyle))
+                .isInstanceOf(InvalidStyleException.class)
+                .hasMessage(STYLE_NOT_FOUND, invalidAfterStudyStyle);
+    }
+}

--- a/src/test/java/com/woowa/supp/domain/surveyee/style/BreaktimeStyleTest.java
+++ b/src/test/java/com/woowa/supp/domain/surveyee/style/BreaktimeStyleTest.java
@@ -1,0 +1,26 @@
+package com.woowa.supp.domain.surveyee.style;
+
+import static com.woowa.supp.domain.surveyee.style.InvalidStyleException.*;
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class BreaktimeStyleTest {
+    @Test
+    void of() {
+        BreaktimeStyle expected = BreaktimeStyle.NO_BREAK;
+        BreaktimeStyle actual = BreaktimeStyle.of("저는 진짜 힘들때까진 계속 코딩 하는 편이에요.");
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void of_GivenInvalidBreaktimeStyle() {
+        String invalidBreaktimeStyle = "못해 안해";
+
+        assertThatThrownBy(() -> BreaktimeStyle.of(invalidBreaktimeStyle))
+                .isInstanceOf(InvalidStyleException.class)
+                .hasMessage(STYLE_NOT_FOUND, invalidBreaktimeStyle);
+    }
+}

--- a/src/test/java/com/woowa/supp/domain/surveyee/style/ComputerPreferStyleTest.java
+++ b/src/test/java/com/woowa/supp/domain/surveyee/style/ComputerPreferStyleTest.java
@@ -1,0 +1,26 @@
+package com.woowa.supp.domain.surveyee.style;
+
+import static com.woowa.supp.domain.surveyee.style.InvalidStyleException.*;
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class ComputerPreferStyleTest {
+    @Test
+    void of() {
+        ComputerPreferStyle expected = ComputerPreferStyle.MY_COMPUTER;
+        ComputerPreferStyle actual = ComputerPreferStyle.of("내 컴퓨터");
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void of_GivenInvalidComputerPreferStyle() {
+        String invalidComputerPreferStyle = "그램이 좋아요";
+
+        assertThatThrownBy(() -> ComputerPreferStyle.of(invalidComputerPreferStyle))
+                .isInstanceOf(InvalidStyleException.class)
+                .hasMessage(STYLE_NOT_FOUND, invalidComputerPreferStyle);
+    }
+}

--- a/src/test/java/com/woowa/supp/domain/surveyee/style/OSStyleTest.java
+++ b/src/test/java/com/woowa/supp/domain/surveyee/style/OSStyleTest.java
@@ -1,0 +1,26 @@
+package com.woowa.supp.domain.surveyee.style;
+
+import static com.woowa.supp.domain.surveyee.style.InvalidStyleException.*;
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class OSStyleTest {
+    @Test
+    void of() {
+        OSStyle expected = OSStyle.APPLE;
+        OSStyle actual = OSStyle.of("사과");
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void of_GivenInvalidOSStyle() {
+        String invalidOSStyle = "티맥스";
+
+        assertThatThrownBy(() -> OSStyle.of(invalidOSStyle))
+                .isInstanceOf(InvalidStyleException.class)
+                .hasMessage(STYLE_NOT_FOUND, invalidOSStyle);
+    }
+}

--- a/src/test/java/com/woowa/supp/domain/surveyee/style/PairTurnStyleTest.java
+++ b/src/test/java/com/woowa/supp/domain/surveyee/style/PairTurnStyleTest.java
@@ -1,0 +1,26 @@
+package com.woowa.supp.domain.surveyee.style;
+
+import static com.woowa.supp.domain.surveyee.style.InvalidStyleException.*;
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class PairTurnStyleTest {
+    @Test
+    void of() {
+        PairTurnStyle expected = PairTurnStyle.TURN_BY_TIME;
+        PairTurnStyle actual = PairTurnStyle.of("시간을 정해서 돌아간다.");
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void of_GivenInvalidPairTurnStyle() {
+        String invalidPairTurnStyle = "내가 혼자 할래요.";
+
+        assertThatThrownBy(() -> PairTurnStyle.of(invalidPairTurnStyle))
+                .isInstanceOf(InvalidStyleException.class)
+                .hasMessage(STYLE_NOT_FOUND, invalidPairTurnStyle);
+    }
+}

--- a/src/test/java/com/woowa/supp/service/SurveyServiceTest.java
+++ b/src/test/java/com/woowa/supp/service/SurveyServiceTest.java
@@ -1,5 +1,6 @@
 package com.woowa.supp.service;
 
+import static com.woowa.supp.service.UserNotFoundException.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -37,30 +38,30 @@ public class SurveyServiceTest {
 	@Test
 	public void saveType() {
 		when(surveyeeRepository.findByLogin(any()))
-			.thenReturn(Optional.empty());
+				.thenReturn(Optional.empty());
 
 		when(surveyeeRepository.save(any()))
-			.thenReturn(Surveyee.builder()
-				.id(1L)
-				.build());
+				.thenReturn(Surveyee.builder()
+						.id(1L)
+						.build());
 
 		assertThat(surveyService.saveOrUpdateType(new DeveloperTypeSaveRequestDto("Mad Scientist"),
-			new SessionUser(new User()))).isEqualTo(1L);
+				new SessionUser(new User()))).isEqualTo(1L);
 	}
 
 	@Test
 	public void updateType() {
 		when(surveyeeRepository.findByLogin(any()))
-			.thenReturn(Optional.of(Surveyee.builder().id(1L).build()));
+				.thenReturn(Optional.of(Surveyee.builder().id(1L).build()));
 
 		assertThat(surveyService.saveOrUpdateType(new DeveloperTypeSaveRequestDto("Mad Scientist"),
-			new SessionUser(new User()))).isEqualTo(1L);
+				new SessionUser(new User()))).isEqualTo(1L);
 	}
 
 	@Test
 	public void saveStyle() {
 		when(surveyeeRepository.findByLogin(any()))
-			.thenReturn(Optional.of(Surveyee.builder().id(1L).build()));
+				.thenReturn(Optional.of(Surveyee.builder().id(1L).build()));
 
 		Map<String, Object> styles = new HashMap<>();
 		styles.put("0", "사과");
@@ -78,7 +79,7 @@ public class SurveyServiceTest {
 	@Test
 	public void saveStyleWhenNoSurveyee() {
 		when(surveyeeRepository.findByLogin(any()))
-			.thenReturn(Optional.empty());
+				.thenReturn(Optional.empty());
 
 		Map<String, Object> styles = new HashMap<>();
 		styles.put("0", "사과");
@@ -90,9 +91,9 @@ public class SurveyServiceTest {
 		styles.put("6", new LinkedHashMap<String, String>());
 		styles.put("7", "test");
 
-		assertThatIllegalArgumentException()
-			.isThrownBy(() -> surveyService.saveStyle(styles, new SessionUser(new User())))
-			.withMessageContaining("존재하지 않는 surveyee 입니다. sessionUser = ");
+		assertThatThrownBy(() -> surveyService.saveStyle(styles, new SessionUser(new User())))
+				.isInstanceOf(UserNotFoundException.class)
+				.hasMessageContaining(String.format(USER_NOT_FOUND, "null"));
 	}
 
 	@Test
@@ -104,7 +105,7 @@ public class SurveyServiceTest {
 	@Test
 	public void findByUser() {
 		when(surveyeeRepository.findByLogin(any()))
-			.thenReturn(Optional.of(Surveyee.builder().build()));
+				.thenReturn(Optional.of(Surveyee.builder().build()));
 
 		surveyService.findByUser(new SessionUser(new User()));
 		verify(surveyeeRepository).findByLogin(any());
@@ -113,18 +114,17 @@ public class SurveyServiceTest {
 	@Test
 	public void findByUserWhenNoUser() {
 		when(surveyeeRepository.findByLogin(any()))
-			.thenReturn(Optional.empty());
-
-		assertThatIllegalArgumentException()
-			.isThrownBy(() -> surveyService.findByUser(new SessionUser(new User())))
-			.withMessageContaining("존재하지 않는 유저 입니다. name = ");
+				.thenReturn(Optional.empty());
+		assertThatThrownBy(() -> surveyService.findByUser(new SessionUser(new User())))
+				.isInstanceOf(UserNotFoundException.class)
+				.hasMessageContaining(String.format(USER_NOT_FOUND, "null"));
 	}
 
 	@Test
 	public void findByLogin() {
 		String login = "login";
 		when(surveyeeRepository.findByLogin(login))
-			.thenReturn(Optional.of(Surveyee.builder().build()));
+				.thenReturn(Optional.of(Surveyee.builder().build()));
 		surveyService.findByLogin(login);
 		verify(surveyeeRepository).findByLogin(login);
 	}
@@ -133,10 +133,10 @@ public class SurveyServiceTest {
 	public void findByLoginWhenNoUser() {
 		String login = "login";
 		when(surveyeeRepository.findByLogin(login))
-			.thenReturn(Optional.empty());
+				.thenReturn(Optional.empty());
 
-		assertThatIllegalArgumentException()
-			.isThrownBy(() -> surveyService.findByLogin(login))
-			.withMessageContaining("존재하지 않는 유저 입니다. id = ");
+		assertThatThrownBy(() -> surveyService.findByLogin(login))
+				.isInstanceOf(UserNotFoundException.class)
+				.hasMessageContaining(String.format(USER_NOT_FOUND, login));
 	}
 }


### PR DESCRIPTION
- UserNotFoundException, InvalidStyleException 생성
- stacktrace가 필요 없는 예외라 생각하여 성능 최적화를 위해 fillInStackTrace() 오버라이딩
  - 두 예외는 단순히 값의 유효성에 따라 하위 로직을 제한하는 용도
- controller Advice를 생성하여 예상한 예외에 대해 bad request, 예상치 못한 예외에 대해 internal server error를 응답하도록 작성
- AfterStudyStyle, BreaktimeStyle, ComputerPreferStyle, OSStyle, PairTurnStyle, DeveloperType 에 대한 테스트 작성
 
closes #87