### PR TITLE
스프링 부트 버전 변경 및 의존성 정리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '2.1.9.RELEASE'
+        springBootVersion = '2.3.1.RELEASE'
     }
     repositories {
         mavenCentral()
@@ -26,7 +26,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     compile('org.jsoup:jsoup:1.13.1')
     compile('org.springframework.boot:spring-boot-starter-web')
     compile('org.projectlombok:lombok')
@@ -37,12 +36,8 @@ dependencies {
     compile("org.mariadb.jdbc:mariadb-java-client")
     compile('org.springframework.session:spring-session-jdbc')
 
-    testImplementation('org.springframework.boot:spring-boot-starter-test') {
-        exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
-    }
+    testImplementation('org.springframework.boot:spring-boot-starter-test')
     testCompile('org.springframework.security:spring-security-test')
     testCompile('io.rest-assured:rest-assured:3.3.0')
     testCompile('com.h2database:h2')
-    testCompile('org.mockito:mockito-core')
-    testCompile('org.mockito:mockito-junit-jupiter')
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Mon Mar 16 16:36:40 KST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### 문제
- 테스트를 추가하면서 Junit5를 사용하게 됨
- 지금은 boot버전이 2.1.9라 따로 jupiter 및 Mockito 의존성을 추가해서 사용하는 형태.
- 그에 따라 boot 버전을 올려서 사용하는 게 깔끔할 것 같음 (지금 부트와 테스트 모듈들 버전이 따로 관리되고 있는 문제가 있기 때문에)

### 전달사항
- gradle 4.9 -> 6.3
- spring boot 2.1.9 -> 2.3.1
- 분리되어 있던 테스트 관련 의존성 제거

closes #86 